### PR TITLE
Dockerfile: Add development files containing Python.h

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN dpkg --add-architecture i386 && \
 	libglib2.0-dev \
 	libgtk2.0-0 \
 	libpcap-dev \
+	libpython3-dev \
 	libsdl2-dev:i386 \
 	libtool \
 	locales \


### PR DESCRIPTION
libpython3-dev contains the required Python.h file, without
it compiling packages fail with

building 'psutil._psutil_linux' extension
  creating build/temp.linux-x86_64-3.6
  creating build/temp.linux-x86_64-3.6/psutil
  x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_SIZEOF_PID_T=4 -DPSUTIL_VERSION=570 -DPSUTIL_LINUX=1 -I/usr/include/python3.6m -c psutil/_psutil_common.c -o build/temp.linux-x86_64-3.6/psutil/_psutil_common.o
  psutil/_psutil_common.c:9:10: fatal error: Python.h: No such file or directory
   #include <Python.h>
            ^~~~~~~~~~
  compilation terminated.
  error: command 'x86_64-linux-gnu-gcc' failed with exit status 1

Fixes: #29

Signed-off-by: Patrik Flykt <patrik.flykt@linux.intel.com>